### PR TITLE
Fix bug in generate promp using 'instruction' instead of 'input'

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -37,7 +37,7 @@ data = load_dataset("json", data_files="alpaca_data.json")
 
 def generate_prompt(data_point):
     # sorry about the formatting disaster gotta move fast
-    if data_point["instruction"]:
+    if data_point["input"]:
         return f"""Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
 
 ### Instruction:


### PR DESCRIPTION
According to the Alpaca README, we should make the distinction 
> for examples with a non-empty input field:

but seems you checked for empty `"instruction"` :)