### PR TITLE
Update alpaca-lora to use camelcase convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,13 @@ Without hyperparameter tuning or validation-based checkpointing, the LoRA model 
 
 ### Setup
 
-Until Jason Phang's [LLaMA implementation](https://github.com/huggingface/transformers/pull/21955)
-is merged, users will need to replace their local `transformers` package.
-
-1. Install dependencies (**install zphang's transformers fork**)
+1. Install dependencies
 
 ```
 pip install -q datasets loralib sentencepiece
 
 pip uninstall transformers
-pip install -q git+https://github.com/zphang/transformers@c3dc391
+pip install -q git+https://github.com/huggingface/transformers.git
 
 pip install -q git+https://github.com/huggingface/peft.git
 ```

--- a/export_state_dict_checkpoint.py
+++ b/export_state_dict_checkpoint.py
@@ -3,11 +3,11 @@ import json
 
 import torch
 from peft import PeftModel, LoraConfig
-from transformers import LLaMATokenizer, LLaMAForCausalLM
+from transformers import LlamaTokenizer, LlamaForCausalLM
 
-tokenizer = LLaMATokenizer.from_pretrained("decapoda-research/llama-7b-hf")
+tokenizer = LlamaTokenizer.from_pretrained("decapoda-research/llama-7b-hf")
 
-base_model = LLaMAForCausalLM.from_pretrained(
+base_model = LlamaForCausalLM.from_pretrained(
     "decapoda-research/llama-7b-hf",
     load_in_8bit=False,
     torch_dtype=torch.float16,

--- a/finetune.py
+++ b/finetune.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import bitsandbytes as bnb
 from datasets import load_dataset
 import transformers
-from transformers import AutoTokenizer, AutoConfig, LLaMAForCausalLM, LLaMATokenizer
+from transformers import AutoTokenizer, AutoConfig, LlamaForCausalLM, LlamaTokenizer
 from peft import prepare_model_for_int8_training, LoraConfig, get_peft_model
 
 
@@ -21,12 +21,12 @@ LORA_R = 8
 LORA_ALPHA = 16
 LORA_DROPOUT = 0.05
 
-model = LLaMAForCausalLM.from_pretrained(
+model = LlamaForCausalLM.from_pretrained(
     "decapoda-research/llama-7b-hf",
     load_in_8bit=True,
     device_map="auto",
 )
-tokenizer = LLaMATokenizer.from_pretrained(
+tokenizer = LlamaTokenizer.from_pretrained(
     "decapoda-research/llama-7b-hf", add_eos_token=True
 )
 

--- a/generate.py
+++ b/generate.py
@@ -1,10 +1,10 @@
 import torch
 from peft import PeftModel
-from transformers import LLaMATokenizer, LLaMAForCausalLM, GenerationConfig
+from transformers import LlamaTokenizer, LlamaForCausalLM, GenerationConfig
 
-tokenizer = LLaMATokenizer.from_pretrained("decapoda-research/llama-7b-hf")
+tokenizer = LlamaTokenizer.from_pretrained("decapoda-research/llama-7b-hf")
 
-model = LLaMAForCausalLM.from_pretrained(
+model = LlamaForCausalLM.from_pretrained(
     "decapoda-research/llama-7b-hf",
     load_in_8bit=True,
     torch_dtype=torch.float16,

--- a/lengths.ipynb
+++ b/lengths.ipynb
@@ -19,10 +19,10 @@
    ],
    "source": [
     "from datasets import load_dataset\n",
-    "from transformers import LLaMATokenizer\n",
+    "from transformers import LlamaTokenizer\n",
     "\n",
     "\n",
-    "tokenizer = LLaMATokenizer.from_pretrained(\"decapoda-research/llama-7b-hf\", add_eos_token=True)\n",
+    "tokenizer = LlamaTokenizer.from_pretrained(\"decapoda-research/llama-7b-hf\", add_eos_token=True)\n",
     "tokenizer.pad_token = tokenizer.eos_token\n",
     "tokenizer.pad_token_id = tokenizer.eos_token_id\n",
     "\n",


### PR DESCRIPTION
## What does this PR do?

[The LLaMA PR](https://github.com/huggingface/transformers/pull/21955) was merged with some slight changes to the transformers class names. I wanted to play around with it so I modified `alpaca-lora` to fit the new convention and use the `main` branch. 

Context:
> [zphang](https://github.com/zphang) commented [yesterday](https://github.com/huggingface/transformers/pull/21955#issuecomment-1469392712)
> I've pushed another breaking change to the code (renaming all LLaMA tokenizer, configuration and model classes to match the camelcase convention in HF Transformers (LLaMA* -> Llama*). This will require updating code, or at minimum, updating the configuration files for the tokenizers and models.
 