### PR TITLE
Update generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -7,7 +7,6 @@ tokenizer = LLaMATokenizer.from_pretrained("decapoda-research/llama-7b-hf")
 model = LLaMAForCausalLM.from_pretrained(
     "decapoda-research/llama-7b-hf",
     load_in_8bit=True,
-    torch_dtype=torch.float16,
     device_map="auto",
 )
 model = PeftModel.from_pretrained(


### PR DESCRIPTION
This PR fixes a small nit; in fact when calling `load_in_8bit=True`, there is no need to specify `torch_dtype=torch.float16` as it gets automatically overriden