### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && apt-get install -y \
     && python3.10 -m pip install -r requirements.txt \
     && python3.10 -m pip install numpy --pre torch --force-reinstall --index-url https://download.pytorch.org/whl/nightly/cu118
 COPY . .
-ENTRYPOINT [ "python3.10", "finetune.py" ]
+ENTRYPOINT [ "python3.10" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+ARG DEBIAN_FRONTEND=noninteractive
+# since bytesands will use the installed cuda version, I have fixed to 11.8 and cannot use easily torch2.0 or nvidia with pytorch containers
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt install -y python3.10 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+COPY requirements.txt requirements.txt
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+RUN python3.10 -m pip install -r requirements.txt
+# install torch==2.1
+RUN python3.10 -m pip install numpy --pre torch --force-reinstall --index-url https://download.pytorch.org/whl/nightly/cu118
+COPY . .
+ENTRYPOINT [ "python3.10", "finetune.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /workspace
+COPY requirements.txt requirements.txt
 # since bytesands will use the installed cuda version, I have fixed to 11.8 and cannot use easily torch2.0 or nvidia with pytorch containers
 RUN apt-get update && apt-get install -y \
     git \
@@ -7,12 +9,9 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt install -y python3.10 \
-    && rm -rf /var/lib/apt/lists/*
-WORKDIR /workspace
-COPY requirements.txt requirements.txt
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-RUN python3.10 -m pip install -r requirements.txt
-# install torch==2.1
-RUN python3.10 -m pip install numpy --pre torch --force-reinstall --index-url https://download.pytorch.org/whl/nightly/cu118
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 \
+    && python3.10 -m pip install -r requirements.txt \
+    && python3.10 -m pip install numpy --pre torch --force-reinstall --index-url https://download.pytorch.org/whl/nightly/cu118
 COPY . .
 ENTRYPOINT [ "python3.10", "finetune.py" ]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ pip install -r requirements.txt
 
 2. If bitsandbytes doesn't work, [install it from source.](https://github.com/TimDettmers/bitsandbytes/blob/main/compile_from_source.md) Windows users can follow [these instructions](https://github.com/tloen/alpaca-lora/issues/17).
 
+#### Docker
+
+```
+docker run --gpus=all --ipc=host --shm-size 64g -v ${HOME}/.cache:/root/.cache --entrypoint /bin/bash --rm -it alpaca-lora
+```
+
+```
+docker run --gpus=all --ipc=host --shm-size 64g -v ${HOME}/.cache:/root/.cache --rm -it alpaca-lora
+```
+
 ### Inference (`generate.py`)
 
 This file reads the foundation model from the Hugging Face model hub and the LoRA weights from `tloen/alpaca-lora-7b`, and runs a Gradio interface for inference on a specified input. Users should treat this as example code for the use of the model, and modify it as needed.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ pip install -r requirements.txt
 
 #### Docker
 
+You can use `docker` with build in support for `torch==2.1.0` and `bytesands`
+
 ```
-docker run --gpus=all --ipc=host --shm-size 64g -v ${HOME}/.cache:/root/.cache --entrypoint /bin/bash --rm -it alpaca-lora
+docker build -t alpaca-lora .
 ```
+
+Then, run it by mapping your local `.cache` folder to the container
 
 ```
 docker run --gpus=all --ipc=host --shm-size 64g -v ${HOME}/.cache:/root/.cache --rm -it alpaca-lora

--- a/README.md
+++ b/README.md
@@ -39,42 +39,30 @@ docker build -t alpaca-lora .
 > **Note**
 > Building the image will take several minutes
 
-Then, run it by mapping your local `.cache` folder to the container
+Then, run it by mapping your local `.cache` folder to the container (and your output folder if you are training.)
 
 ```bash
 docker run --gpus=all --ipc=host --shm-size 64g \
   -v ${HOME}/.cache:/root/.cache \
   -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
-  --rm -it alpaca-lora
+  --rm -it alpaca-lora training.py
 ```
 
 You mapped the host `.cache` folder to the container to persist the original model checkpoint in future runs.
 
-You can also pass custom env variables to change training behaviour, see [Training](#training-finetunepy) for more information.
-
-```bash
-docker run --gpus=all --ipc=host --shm-size 64g \
-  -e MICRO_BATCH_SIZE=5 \
-  -e BATCH_SIZE=256 \
-  -e GRADIENT_ACCUMULATION_STEPS=64 \
-  -e EPOCHS=5 \
-  -e LEARNING_RATE=0.001 \
-  -e CUTOFF_LEN=512 \
-  -e LORA_R=16 \
-  -e LORA_ALPHA=32 \
-  -e LORA_DROPOUT=0.1 \
-  -e VAL_SET_SIZE=5000 \
-  -e TARGET_MODULES="q_proj,v_proj,a_proj" \
-  -e DATA_PATH="/path/to/data.json" \
-  -e OUTPUT_DIR="/path/to/output" \
-  -v ${HOME}/.cache:/root/.cache \
-  -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
-  --rm -it alpaca-lora
-```
-
 ### Inference (`generate.py`)
 
 This file reads the foundation model from the Hugging Face model hub and the LoRA weights from `tloen/alpaca-lora-7b`, and runs a Gradio interface for inference on a specified input. Users should treat this as example code for the use of the model, and modify it as needed.
+
+#### Docker
+
+```bash
+docker run --gpus=all --ipc=host --shm-size 64g \
+  -v ${HOME}/.cache:/root/.cache \
+  -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
+  -p 7860:7860 \
+  --rm -it alpaca-lora generate.py
+```
 
 ### Training (`finetune.py`)
 
@@ -100,6 +88,28 @@ You can quickly change different training variables by using the following env v
 | `TARGET_MODULES`              | The list of target modules to extract from the model      | `["q_proj", "v_proj"]`       | `python train.py --target_modules=q_proj,v_proj,a_proj` | `docker run my-image python train.py --target_modules=q_proj,v_proj,a_proj`                               |
 | `DATA_PATH`                   | The path to the data file                                 | `"alpaca_data_cleaned.json"` | `python train.py --data_path=/path/to/data.json`        | `docker run -v /host/path:/container/path my-image python train.py --data_path=/container/path/data.json` |
 | `OUTPUT_DIR`                  | The directory to save the model checkpoints and logs      | `"lora-alpaca"`              | `python train.py --output_dir=/path/to/output`          | `docker run -v /host/path:/container/path my-image python train.py --output_dir=/container/path/output`   |
+
+#### Docker
+
+```bash
+docker run --gpus=all --ipc=host --shm-size 64g \
+  -e MICRO_BATCH_SIZE=5 \
+  -e BATCH_SIZE=256 \
+  -e GRADIENT_ACCUMULATION_STEPS=64 \
+  -e EPOCHS=5 \
+  -e LEARNING_RATE=0.001 \
+  -e CUTOFF_LEN=512 \
+  -e LORA_R=16 \
+  -e LORA_ALPHA=32 \
+  -e LORA_DROPOUT=0.1 \
+  -e VAL_SET_SIZE=5000 \
+  -e TARGET_MODULES="q_proj,v_proj,a_proj" \
+  -e DATA_PATH="/path/to/data.json" \
+  -e OUTPUT_DIR="/path/to/output" \
+  -v ${HOME}/.cache:/root/.cache \
+  -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
+  --rm -it alpaca-lora training.py
+```
 
 ### Checkpoint export (`export_*_checkpoint.py`)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You mapped the host `.cache` folder to the container to persist the original mod
 You can also pass custom env variables to change training behaviour, see [Training](#training-finetunepy) for more information.
 
 ```bash
-docker run --gpus=0 --ipc=host --shm-size 64g \
+docker run --gpus=all --ipc=host --shm-size 64g \
   -e MICRO_BATCH_SIZE=5 \
   -e BATCH_SIZE=256 \
   -e GRADIENT_ACCUMULATION_STEPS=64 \
@@ -69,7 +69,7 @@ docker run --gpus=0 --ipc=host --shm-size 64g \
   -e OUTPUT_DIR="/path/to/output" \
   -v ${HOME}/.cache:/root/.cache \
   -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
-  --rm -it my-image
+  --rm -it alpaca-lora
 ```
 
 ### Inference (`generate.py`)

--- a/finetune.py
+++ b/finetune.py
@@ -20,22 +20,19 @@ from peft import (
 
 
 # optimized for RTX 4090. for larger GPUs, increase some of these?
-MICRO_BATCH_SIZE = 4  # this could actually be 5 but i like powers of 2
-BATCH_SIZE = 128
+MICRO_BATCH_SIZE = int(os.environ.get('MICRO_BATCH_SIZE', '4'))  # this could actually be 5 but i like powers of 2
+BATCH_SIZE = int(os.environ.get('BATCH_SIZE', '128'))
 GRADIENT_ACCUMULATION_STEPS = BATCH_SIZE // MICRO_BATCH_SIZE
-EPOCHS = 3  # we don't always need 3 tbh
-LEARNING_RATE = 3e-4  # the Karpathy constant
-CUTOFF_LEN = 256  # 256 accounts for about 96% of the data
-LORA_R = 8
-LORA_ALPHA = 16
-LORA_DROPOUT = 0.05
-VAL_SET_SIZE = 2000
-TARGET_MODULES = [
-    "q_proj",
-    "v_proj",
-]
-DATA_PATH = "alpaca_data_cleaned.json"
-OUTPUT_DIR = "lora-alpaca"
+EPOCHS = int(os.environ.get('EPOCHS', '3'))  # we don't always need 3 tbh
+LEARNING_RATE = float(os.environ.get('LEARNING_RATE', '3e-4'))  # the Karpathy constant
+CUTOFF_LEN = int(os.environ.get('CUTOFF_LEN', '256'))  # 256 accounts for about 96% of the data
+LORA_R = int(os.environ.get('LORA_R', '8'))
+LORA_ALPHA = int(os.environ.get('LORA_ALPHA', '16'))
+LORA_DROPOUT = float(os.environ.get('LORA_DROPOUT', '0.05'))
+VAL_SET_SIZE = int(os.environ.get('VAL_SET_SIZE', '2000'))
+TARGET_MODULES = os.environ.get('TARGET_MODULES', 'q_proj,v_proj').split(',')
+DATA_PATH = os.environ.get('DATA_PATH', 'alpaca_data_cleaned.json')
+OUTPUT_DIR = os.environ.get('OUTPUT_DIR', 'lora-alpaca')
 
 device_map = "auto"
 world_size = int(os.environ.get("WORLD_SIZE", 1))
@@ -107,55 +104,8 @@ def tokenize(prompt):
 
 
 def generate_and_tokenize_prompt(data_point):
-    # This function masks out the labels for the input,
-    # so that our loss is computed only on the response.
-    user_prompt = (
-        (
-            f"""Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
-
-### Instruction:
-{data_point["instruction"]}
-
-### Input:
-{data_point["input"]}
-
-### Response:
-"""
-        )
-        if data_point["input"]
-        else (
-            f"""Below is an instruction that describes a task. Write a response that appropriately completes the request.
-
-### Instruction:
-{data_point["instruction"]}
-
-### Response:
-"""
-        )
-    )
-    len_user_prompt_tokens = (
-        len(
-            tokenizer(
-                user_prompt,
-                truncation=True,
-                max_length=CUTOFF_LEN + 1,
-                padding="max_length",
-            )["input_ids"]
-        )
-        - 1
-    )  # no eos token
-    full_tokens = tokenizer(
-        user_prompt + data_point["output"],
-        truncation=True,
-        max_length=CUTOFF_LEN + 1,
-        padding="max_length",
-    )["input_ids"][:-1]
-    return {
-        "input_ids": full_tokens,
-        "labels": [-100] * len_user_prompt_tokens
-        + full_tokens[len_user_prompt_tokens:],
-        "attention_mask": [1] * (len(full_tokens)),
-    }
+    prompt = generate_prompt(data_point)
+    return tokenize(prompt)
 
 
 if VAL_SET_SIZE > 0:
@@ -165,7 +115,7 @@ if VAL_SET_SIZE > 0:
     train_data = train_val["train"].shuffle().map(generate_and_tokenize_prompt)
     val_data = train_val["test"].shuffle().map(generate_and_tokenize_prompt)
 else:
-    train_data = data['train'].shuffle().map(generate_and_tokenize_prompt)
+    train_data = data["train"].shuffle().map(generate_and_tokenize_prompt)
     val_data = None
 
 trainer = transformers.Trainer(
@@ -198,7 +148,7 @@ model.state_dict = (
     lambda self, *_, **__: get_peft_model_state_dict(self, old_state_dict())
 ).__get__(model, type(model))
 
-if torch.__version__ >= "2" and sys.platform != 'win32':
+if torch.__version__ >= "2" and sys.platform != "win32":
     model = torch.compile(model)
 
 trainer.train()


### PR DESCRIPTION
## Description
This PR adds a `Dockerfile` to quickly run the `finetune.py` script without losing sanity

## Usage

Build the container

```bash
docker build -t alpaca-lora .
```

Run it, 

**Training**:

```bash
docker run --gpus=all --ipc=host --shm-size 64g \
  -v ${HOME}/.cache:/root/.cache \
  -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
  --rm -it alpaca-lora finetune.py \
  --base_model 'decapoda-research/llama-7b-hf' \
  --data_path 'yahma/alpaca-cleaned' \
  --output_dir './lora-alpaca' \
  --batch_size 128 \
  --micro_batch_size 4 \
  --num_epochs 3 \
  --learning_rate 1e-4 \
  --cutoff_len 512 \
  --val_set_size 2000 \
  --lora_r 8 \
  --lora_alpha 16 \
  --lora_dropout 0.05 \
  --lora_target_modules '[q_proj,v_proj]' \
  --train_on_inputs \
  --group_by_length
```

**Generation**

```bash
docker run --gpus=all --ipc=host --shm-size 64g \
  -v ${HOME}/.cache:/root/.cache \
  -v ${PWD}/lora-alpaca:/workspace/lora-alpaca \
  -p 7860:7860 \
  --rm -it alpaca-lora generate.py
  ```

Then natigate to `https://localhost:7860`

all good!

![image](https://user-images.githubusercontent.com/15908060/226303701-8a2cecef-9844-4de2-809e-94e123e2bce5.png)

### TODOs

- [x] add more env variables to control training