### PR TITLE
Attention mask counts padding tokens

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -143,17 +143,18 @@ def generate_and_tokenize_prompt(data_point):
         )
         - 1
     )  # no eos token
-    full_tokens = tokenizer(
+    full_tokens = tokenizer.encode_plus(
         user_prompt + data_point["output"],
         truncation=True,
-        max_length=CUTOFF_LEN + 1,
+        max_length=CUTOFF_LEN,
         padding="max_length",
-    )["input_ids"][:-1]
+    )["input_ids"]
+    full_tokens = encodings["input_ids"]
+    attention_mask = encodings["attention_mask"]
     return {
         "input_ids": full_tokens,
-        "labels": [-100] * len_user_prompt_tokens
-        + full_tokens[len_user_prompt_tokens:],
-        "attention_mask": [1] * (len(full_tokens)),
+        "labels": [-100] * len_user_prompt_tokens + full_tokens[len_user_prompt_tokens:],
+        "attention_mask": attention_mask
     }
 
 


### PR DESCRIPTION
I notice the attention mask in the function `generate_and_tokenize_prompt` is weird.

If we set attention masks like 
```python
"attention_mask": [1] * (len(full_tokens))
```
then, the padded token will be counted to calculate the attention matrix.

Therefore, we can make use of the encode_plus to directly get the attention mask without padded tokens
