### PR TITLE
Enabling model parallelism (training 30b on 2x 3090s and beyond)

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -171,7 +171,7 @@ def train(
         val_data = None
 
     if not ddp and torch.cuda.device_count() > 1:
-        #keeps Trainer from trying it's own DataParallelism when more than 1 gpu is available
+        # keeps Trainer from trying its own DataParallelism when more than 1 gpu is available
         model.is_parallelizable = True
         model.model_parallel = True
         

--- a/finetune.py
+++ b/finetune.py
@@ -170,6 +170,11 @@ def train(
         train_data = data["train"].shuffle().map(generate_and_tokenize_prompt)
         val_data = None
 
+    if not ddp and torch.cuda.device_count() > 1:
+        #keeps Trainer from trying it's own DataParallelism when more than 1 gpu is available
+        model.is_parallelizable = True
+        model.model_parallel = True
+        
     trainer = transformers.Trainer(
         model=model,
         train_dataset=train_data,

--- a/finetune.py
+++ b/finetune.py
@@ -174,7 +174,7 @@ def train(
         # keeps Trainer from trying its own DataParallelism when more than 1 gpu is available
         model.is_parallelizable = True
         model.model_parallel = True
-        
+
     trainer = transformers.Trainer(
         model=model,
         train_dataset=train_data,

--- a/generate.py
+++ b/generate.py
@@ -28,9 +28,9 @@ def main(
     base_model: str = "",
     lora_weights: str = "tloen/alpaca-lora-7b",
 ):
-    assert base_model, (
-        "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
-    )
+    assert (
+        base_model
+    ), "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
 
     tokenizer = LlamaTokenizer.from_pretrained(base_model)
     if device == "cuda":


### PR DESCRIPTION
Does as it says on the tin.
Now multi-gpu users can choose to use them for faster training (DDP) or bigger models (MP)

This required a minor change to the transformers library. It has been merged: [PR](https://github.com/huggingface/transformers/pull/22329). Just update by reinstalling the transformers module.

This also serves as a workaround for #8 