### PR TITLE
[RFC] Experimental dynamic batching

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -98,7 +98,7 @@ def tokenize(prompt):
         prompt,
         truncation=True,
         max_length=CUTOFF_LEN + 1,
-        padding="max_length",
+        padding=True,
     )
     return {
         "input_ids": result["input_ids"][:-1],
@@ -141,6 +141,7 @@ trainer = transformers.Trainer(
         save_total_limit=3,
         load_best_model_at_end=True if VAL_SET_SIZE > 0 else False,
         ddp_find_unused_parameters=False if ddp else None,
+        group_by_length=True,
     ),
     data_collator=transformers.DataCollatorForLanguageModeling(tokenizer, mlm=False),
 )


### PR DESCRIPTION
I am a complete beginner to this, so my understanding may be completely wrong.
This PR should enable dynamic batching, making the CUTOFF_LEN a maximum, rather than a hard limit.
Enabling dynamic batching seems to significantly reduce training times, at the cost of losing input randomization due to the grouping of the training data and losing accurate ETAs.
It also allows one to run with i.e. CUTOFF_LEN = 1024 (if you have enough VRAM for that, seems like there's memory optimizations in newer PyTorch), allowing you to fit the entire dataset without truncation, without the massive slowdowns you normally get with a high sequence length.

This PR does just the bare minimum to enable dynamic batching, and I have yet to observe the results of a fully trained model (it still takes hours to train, just slightly fewer...), and I don't even know if it makes sense to begin with, but I figured I'd make a PR so others can give their thoughts.