### PR TITLE
Feat: Add wandb

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -55,7 +55,7 @@ def train(
     wandb_project: str = "",
     wandb_run_name: str = "",
     wandb_watch: str = "", # options: false | gradients | all
-    wandb_log_model: str = "" # options: false | true
+    wandb_log_model: str = "", # options: false | true
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
 ):
     print(

--- a/finetune.py
+++ b/finetune.py
@@ -46,7 +46,9 @@ def train(
     group_by_length: bool = True,  # faster, but produces an odd training loss curve
     # wandb params
     wandb_project: str = "",
-    run_name: str = ""
+    run_name: str = "",
+    wandb_watch: str = "", # options: false | gradients | all
+    wandb_log_model: str = "" # options: false | true
 ):
     print(
         f"Training Alpaca-LoRA model with params:\n"
@@ -67,6 +69,8 @@ def train(
         f"group_by_length: {group_by_length}\n"
         f"wandb_project: {wandb_project}\n"
         f"run_name: {run_name}\n"
+        f"wandb_watch: {wandb_watch}\n"
+        f"wandb_log_model: {wandb_log_model}\n"
     )
     assert (
         base_model
@@ -83,8 +87,14 @@ def train(
     # Check if parameter passed or if set within environ
     use_wandb = len(wandb_project) > 0 or \
                 ("WANDB_PROJECT" in os.environ and len(os.environ["WANDB_PROJECT"]) > 0)
-    if len(wandb_project) > 0: # only overwrite if param passed
+    # Only overwrite environ if wandb param passed
+    if len(wandb_project) > 0: 
         os.environ['WANDB_PROJECT'] = wandb_project
+    if len(wandb_watch) > 0:
+        os.environ['WANDB_WATCH'] = wandb_watch
+    if len(wandb_log_model) > 0:
+        os.environ['WANDB_LOG_MODEL'] = wandb_log_model
+
 
     model = LlamaForCausalLM.from_pretrained(
         base_model,

--- a/finetune.py
+++ b/finetune.py
@@ -80,8 +80,9 @@ def train(
         device_map = {"": int(os.environ.get("LOCAL_RANK") or 0)}
         gradient_accumulation_steps = gradient_accumulation_steps // world_size
 
-    # wandb
-    use_wandb = len(wandb_project) > 0 or len(os.environ["WANDB_PROJECT"]) > 0
+    # Check if parameter passed or if set within environ
+    use_wandb = len(wandb_project) > 0 or \
+                ("WANDB_PROJECT" in os.environ and len(os.environ["WANDB_PROJECT"]) > 0)
     if len(wandb_project) > 0: # only overwrite if param passed
         os.environ['WANDB_PROJECT'] = wandb_project
 

--- a/finetune.py
+++ b/finetune.py
@@ -231,7 +231,7 @@ def train(
             ddp_find_unused_parameters=False if ddp else None,
             group_by_length=group_by_length,
             report_to="wandb" if use_wandb else None,
-            wandb_run_name=wandb_run_name if use_wandb else None
+            run_name=wandb_run_name if use_wandb else None
         ),
         data_collator=transformers.DataCollatorForSeq2Seq(
             tokenizer, pad_to_multiple_of=8, return_tensors="pt", padding=True

--- a/finetune.py
+++ b/finetune.py
@@ -53,7 +53,7 @@ def train(
     group_by_length: bool = False,  # faster, but produces an odd training loss curve
     # wandb params
     wandb_project: str = "",
-    run_name: str = "",
+    wandb_run_name: str = "",
     wandb_watch: str = "", # options: false | gradients | all
     wandb_log_model: str = "" # options: false | true
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
@@ -76,7 +76,7 @@ def train(
         f"train_on_inputs: {train_on_inputs}\n"
         f"group_by_length: {group_by_length}\n"
         f"wandb_project: {wandb_project}\n"
-        f"run_name: {run_name}\n"
+        f"wandb_run_name: {wandb_run_name}\n"
         f"wandb_watch: {wandb_watch}\n"
         f"wandb_log_model: {wandb_log_model}\n"
         f"resume_from_checkpoint: {resume_from_checkpoint}\n"
@@ -231,7 +231,7 @@ def train(
             ddp_find_unused_parameters=False if ddp else None,
             group_by_length=group_by_length,
             report_to="wandb" if use_wandb else None,
-            run_name=run_name if use_wandb else None
+            wandb_run_name=wandb_run_name if use_wandb else None
         ),
         data_collator=transformers.DataCollatorForSeq2Seq(
             tokenizer, pad_to_multiple_of=8, return_tensors="pt", padding=True


### PR DESCRIPTION
Adds wandb for tracking runs.

Usage: pass 
- `--wandb_project "name" ` 
- `--run_name "name"` (optional)

It also detects if environment already set and passes `report_to='wandb'`

Test run passing `wandb_project` and `run_name`:
```bash
$ python finetune.py --base_model <redact> --output_dir test-report --wandb_project <redact> --run_name test-reporting --data_path '../alpaca_data_cleaned.json'
Training Alpaca-LoRA model with params:
...
wandb_project: <redact>
run_name: test-reporting
...
wandb: Tracking run with wandb version 0.14.0
wandb: Run data is saved locally in <redact>
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run test-reporting
wandb: ⭐️ View project at <redact>
wandb: 🚀 View run at <redact>
```

Test run passing only `wandb_project`:
```
$ python finetune.py --base_model <redact> --output_dir test-report --wandb_project <redact>  --data_path '../alpaca_data_cleaned.json'
Training Alpaca-LoRA model with params:
...
wandb_project: <redact>
run_name:
...
wandb: Tracking run with wandb version 0.14.0
wandb: Run data is saved locally in <redact>
wandb: Run `wandb offline` to turn off syncing.
wandb: Syncing run lucky-grass-17 # <- random name
```