### PR TITLE
add Chinese 13b lora link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ as well as [clusters of bad examples](https://atlas.nomic.ai/map/d2139cc3-bc1c-4
     - https://huggingface.co/samwit/alpaca13B-lora
     - 🇯🇵 https://huggingface.co/kunishou/Japanese-Alapaca-LoRA-13b-v0
     - 🇰🇷 https://huggingface.co/chansung/koalpaca-lora-13b
+    - 🇨🇳 https://huggingface.co/facat/alpaca-lora-cn-13b
   - 30B:
     - https://huggingface.co/baseten/alpaca-30b
     - https://huggingface.co/chansung/alpaca-lora-30b


### PR DESCRIPTION
Hi, I trained llama 13b on a merged dataset from [guancao](https://guanaco-model.github.io/) and [BELLE0.5m](https://github.com/LianjiaTech/BELLE). Would you be so kind as to include the link to my model in this context? This will make it more accessible to a wider audience.