### PR TITLE
Default dataset to cleaned alpaca dataset from HF

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -26,7 +26,7 @@ from transformers import LlamaForCausalLM, LlamaTokenizer  # noqa: F402
 def train(
     # model/data params
     base_model: str = "",  # the only required argument
-    data_path: str = "./alpaca_data_cleaned.json",
+    data_path: str = "yahma/alpaca-cleaned",
     output_dir: str = "./lora-alpaca",
     # training hyperparams
     batch_size: int = 128,


### PR DESCRIPTION
Simple change to default the dataset to the Hugging Face dataset repo for the Cleaned Alpaca dataset, rather than loading the local json, which will likely be out of date.