### PR TITLE
add chinese-alpaca-lora-7b

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ or [alpaca.cpp](https://github.com/antimatter15/alpaca.cpp).
     - 🇹🇭 <https://huggingface.co/Thaweewat/thai-buffala-lora-7b-v0-1>
     - 🇩🇪 <https://huggingface.co/thisserand/alpaca_lora_german>
     - 🇮🇹 <https://huggingface.co/teelinsan/camoscio-7b-llama>
+    - 🇨🇳 <https://huggingface.co/ziqingyang/chinese-alpaca-lora-7b>
   - 13B:
     - <https://huggingface.co/chansung/alpaca-lora-13b>
     - <https://huggingface.co/mattreid/alpaca-lora-13b>


### PR DESCRIPTION
Hello there,
we have just released a 7B Chinese-Alpaca lora model, and added the link in the readme.
I know that there is already a Chinese model in the list, but I was wondering if it would be possible to also include this new Chinese model (which has been trained with a different strategy)?
