### PR TITLE
add 65b checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ docker-compose down --volumes --rmi all
     - <https://huggingface.co/baseten/alpaca-30b>
     - <https://huggingface.co/chansung/alpaca-lora-30b>
     - 🇯🇵 <https://huggingface.co/kunishou/Japanese-Alapaca-LoRA-30b-v0>
+ - 65B
+   - <https://huggingface.co/chansung/alpaca-lora-65b>
 - [alpaca-native](https://huggingface.co/chavinlo/alpaca-native), a replication using the original Alpaca code
 
 ### Example outputs


### PR DESCRIPTION
using the finetune.py with default hyperparameters, this checkpoint was trained on 8xA100(40G) DGX system for 24 hours. the only hyperparameters adjusted were batch size and micro batch size to fully utilize the memory. 