### PR TITLE
Fix readme formatting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ docker-compose down --volumes --rmi all
     - <https://huggingface.co/baseten/alpaca-30b>
     - <https://huggingface.co/chansung/alpaca-lora-30b>
     - 🇯🇵 <https://huggingface.co/kunishou/Japanese-Alapaca-LoRA-30b-v0>
- - 65B
-   - <https://huggingface.co/chansung/alpaca-lora-65b>
+  - 65B
+    - <https://huggingface.co/chansung/alpaca-lora-65b>
 - [alpaca-native](https://huggingface.co/chavinlo/alpaca-native), a replication using the original Alpaca code
 
 ### Example outputs


### PR DESCRIPTION
2 spaces are missing from the README, which doesn't look elegant enough. ^-^

![2 spaces missing](https://user-images.githubusercontent.com/32300960/229994303-508fac0f-dfd4-4e3a-87ae-7765a662e688.png)
