### PR TITLE
Force device_map on the lora PerfModel in generate.py.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -49,6 +49,7 @@ def main(
             model,
             lora_weights,
             torch_dtype=torch.float16,
+            device_map={'': 0}
         )
     elif device == "mps":
         model = LlamaForCausalLM.from_pretrained(


### PR DESCRIPTION
https://github,com/tloen/alpaca-lora/issues/21 is an example but it doesn't appear fixed for me at tip of tree. Possible i need to an update Perf library, will investigate later.