### PR TITLE
Add args for template path and flash attention

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -55,7 +55,7 @@ def train(
     wandb_log_model: str = "",  # options: false | true
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
     prompt_template_name: str = "alpaca",  # The prompt template to use, will default to alpaca.
-    prompt_template_base_path: str = "",
+    prompt_template_base_path: str = "templates",
     flash_attention: bool = True, # Use flash attention
 ):
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:

--- a/finetune.py
+++ b/finetune.py
@@ -56,6 +56,7 @@ def train(
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
     prompt_template_name: str = "alpaca",  # The prompt template to use, will default to alpaca.
     prompt_template_base_path: str = "",
+    flash_attention: bool = True, # Use flash attention
 ):
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:
         print(
@@ -87,6 +88,9 @@ def train(
         base_model
     ), "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
     gradient_accumulation_steps = batch_size // micro_batch_size
+    
+    if flash_attention:
+        torch.backends.cuda.enable_flash_sdp(True)
 
     prompter = Prompter(prompt_template_name, prompt_template_base_path)
 

--- a/finetune.py
+++ b/finetune.py
@@ -55,6 +55,7 @@ def train(
     wandb_log_model: str = "",  # options: false | true
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
     prompt_template_name: str = "alpaca",  # The prompt template to use, will default to alpaca.
+    prompt_template_base_path: str = "",
 ):
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:
         print(
@@ -80,13 +81,14 @@ def train(
             f"wandb_log_model: {wandb_log_model}\n"
             f"resume_from_checkpoint: {resume_from_checkpoint or False}\n"
             f"prompt template: {prompt_template_name}\n"
+            f"prompt template base path: {prompt_template_base_path}\n"
         )
     assert (
         base_model
     ), "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
     gradient_accumulation_steps = batch_size // micro_batch_size
 
-    prompter = Prompter(prompt_template_name)
+    prompter = Prompter(prompt_template_name, prompt_template_base_path)
 
     device_map = "auto"
     world_size = int(os.environ.get("WORLD_SIZE", 1))

--- a/finetune.py
+++ b/finetune.py
@@ -55,7 +55,7 @@ def train(
     wandb_log_model: str = "",  # options: false | true
     resume_from_checkpoint: str = None,  # either training checkpoint or final adapter
     prompt_template_name: str = "alpaca",  # The prompt template to use, will default to alpaca.
-    prompt_template_base_path: str = "templates",
+    prompt_template_path: str = "templates",
     flash_attention: bool = True, # Use flash attention
 ):
     if int(os.environ.get("LOCAL_RANK", 0)) == 0:
@@ -82,7 +82,7 @@ def train(
             f"wandb_log_model: {wandb_log_model}\n"
             f"resume_from_checkpoint: {resume_from_checkpoint or False}\n"
             f"prompt template: {prompt_template_name}\n"
-            f"prompt template base path: {prompt_template_base_path}\n"
+            f"prompt template path: {prompt_template_path}\n"
         )
     assert (
         base_model
@@ -92,7 +92,7 @@ def train(
     if flash_attention:
         torch.backends.cuda.enable_flash_sdp(True)
 
-    prompter = Prompter(prompt_template_name, prompt_template_base_path)
+    prompter = Prompter(prompt_template_name, prompt_template_path)
 
     device_map = "auto"
     world_size = int(os.environ.get("WORLD_SIZE", 1))

--- a/generate.py
+++ b/generate.py
@@ -28,7 +28,7 @@ def main(
     base_model: str = "",
     lora_weights: str = "tloen/alpaca-lora-7b",
     prompt_template: str = "",  # The prompt template to use, will default to alpaca.
-    prompt_template_base_path: str = "",  # The prompt base path.
+    prompt_template_path: str = "templates",  # The prompt base path.
     server_name: str = "0.0.0.0",  # Allows to listen on all interfaces by providing '0.
     share_gradio: bool = False,
 ):
@@ -37,7 +37,7 @@ def main(
         base_model
     ), "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
 
-    prompter = Prompter(prompt_template, prompt_template_base_path)
+    prompter = Prompter(prompt_template, prompt_template_path)
     tokenizer = LlamaTokenizer.from_pretrained(base_model)
     if device == "cuda":
         model = LlamaForCausalLM.from_pretrained(

--- a/generate.py
+++ b/generate.py
@@ -28,6 +28,7 @@ def main(
     base_model: str = "",
     lora_weights: str = "tloen/alpaca-lora-7b",
     prompt_template: str = "",  # The prompt template to use, will default to alpaca.
+    prompt_template_base_path: str = "",  # The prompt base path.
     server_name: str = "0.0.0.0",  # Allows to listen on all interfaces by providing '0.
     share_gradio: bool = False,
 ):
@@ -36,7 +37,7 @@ def main(
         base_model
     ), "Please specify a --base_model, e.g. --base_model='decapoda-research/llama-7b-hf'"
 
-    prompter = Prompter(prompt_template)
+    prompter = Prompter(prompt_template, prompt_template_base_path)
     tokenizer = LlamaTokenizer.from_pretrained(base_model)
     if device == "cuda":
         model = LlamaForCausalLM.from_pretrained(

--- a/utils/prompter.py
+++ b/utils/prompter.py
@@ -10,7 +10,7 @@ from typing import Union
 class Prompter(object):
     __slots__ = ("template", "_verbose")
 
-    def __init__(self, template_name: str = "" base_path: str = "", verbose: bool = False):
+    def __init__(self, template_name: str = "", base_path: str = "", verbose: bool = False):
         self._verbose = verbose
         if not template_name:
             # Enforce the default here, so the constructor can be called with '' and will not break.

--- a/utils/prompter.py
+++ b/utils/prompter.py
@@ -10,12 +10,12 @@ from typing import Union
 class Prompter(object):
     __slots__ = ("template", "_verbose")
 
-    def __init__(self, template_name: str = "", verbose: bool = False):
+    def __init__(self, template_name: str = "" base_path: str = "", verbose: bool = False):
         self._verbose = verbose
         if not template_name:
             # Enforce the default here, so the constructor can be called with '' and will not break.
             template_name = "alpaca"
-        file_name = osp.join("templates", f"{template_name}.json")
+        file_name = osp.join(base_path, "templates", f"{template_name}.json")
         if not osp.exists(file_name):
             raise ValueError(f"Can't read {file_name}")
         with open(file_name) as fp:

--- a/utils/prompter.py
+++ b/utils/prompter.py
@@ -15,7 +15,7 @@ class Prompter(object):
         if not template_name:
             # Enforce the default here, so the constructor can be called with '' and will not break.
             template_name = "alpaca"
-        file_name = osp.join(base_path, "templates", f"{template_name}.json")
+        file_name = osp.join(base_path, f"{template_name}.json")
         if not osp.exists(file_name):
             raise ValueError(f"Can't read {file_name}")
         with open(file_name) as fp:


### PR DESCRIPTION
Add two arguments:

- prompt_template_path: Default to "templates", can be used to pass the template path when working directory is not the alpaca-lora directory.
- flash_attention: Default to True, enables flash attention backend.