### PR TITLE
add Chinese-Alpaca-LoRA 7B and 13B models

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ docker-compose down --volumes --rmi all
     - <https://huggingface.co/samwit/alpaca7B-lora>
     - 🇧🇷 <https://huggingface.co/22h/cabrita-lora-v0-1>
     - 🇨🇳 <https://huggingface.co/qychen/luotuo-lora-7b-0.1>
+    - 🇨🇳 <https://huggingface.co/ziqingyang/chinese-alpaca-lora-7b>
     - 🇯🇵 <https://huggingface.co/kunishou/Japanese-Alapaca-LoRA-7b-v0>
     - 🇫🇷 <https://huggingface.co/bofenghuang/vigogne-lora-7b>
     - 🇹🇭 <https://huggingface.co/Thaweewat/thai-buffala-lora-7b-v0-1>
@@ -178,6 +179,7 @@ docker-compose down --volumes --rmi all
     - 🇯🇵 <https://huggingface.co/kunishou/Japanese-Alapaca-LoRA-13b-v0>
     - 🇰🇷 <https://huggingface.co/chansung/koalpaca-lora-13b>
     - 🇨🇳 <https://huggingface.co/facat/alpaca-lora-cn-13b>
+    - 🇨🇳 <https://huggingface.co/ziqingyang/chinese-alpaca-lora-13b>
     - 🇪🇸 <https://huggingface.co/plncmm/guanaco-lora-13b>
   - 30B:
     - <https://huggingface.co/baseten/alpaca-30b>


### PR DESCRIPTION
Hi, 
previously I added a chinese-alpaca-lora-7b (#208), but it was removed as pointed out by https://github.com/tloen/alpaca-lora/commit/4367a43fcb8c47ff1e520777ad7e60b622edea4d#r106919365. Is this just a merge error or for some reasons?

We have released a 13B Chinese-Alpaca lora model, so in this pull request I add the link to the 13B model and fix the link to the 7B model.