### PR TITLE
Fix label masking length when setting add_eos_token=True and train_on_inputs=False

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -47,6 +47,7 @@ def train(
     ],
     # llm hyperparams
     train_on_inputs: bool = True,  # if False, masks out inputs in loss
+    add_eos_token: bool = False,
     group_by_length: bool = False,  # faster, but produces an odd training loss curve
     # wandb params
     wandb_project: str = "",
@@ -73,6 +74,7 @@ def train(
             f"lora_dropout: {lora_dropout}\n"
             f"lora_target_modules: {lora_target_modules}\n"
             f"train_on_inputs: {train_on_inputs}\n"
+            f"add_eos_token: {add_eos_token}\n"
             f"group_by_length: {group_by_length}\n"
             f"wandb_project: {wandb_project}\n"
             f"wandb_run_name: {wandb_run_name}\n"
@@ -154,8 +156,11 @@ def train(
             user_prompt = prompter.generate_prompt(
                 data_point["instruction"], data_point["input"]
             )
-            tokenized_user_prompt = tokenize(user_prompt, add_eos_token=False)
+            tokenized_user_prompt = tokenize(user_prompt, add_eos_token=add_eos_token)
             user_prompt_len = len(tokenized_user_prompt["input_ids"])
+
+            if add_eos_token:
+                user_prompt_len -= 1
 
             tokenized_full_prompt["labels"] = [
                 -100


### PR DESCRIPTION
If `add_eos_token=True` and `train_on_inputs=False` are set, the first token of response will be masked by -100. Assuming we tokenize the following sample：

```
### Instruction:
<p>I cannot locate within the FAQ whether this functionality exists in the API although its mentioned in a book as something that is potentially available. Has anyone had any experience implementing this feature?</p>

### Response:
As an AI language model, I do not have access to the specific details of the book or the API you are referring to. Please provide more context or information so I can assist you better.</s>
```

After tokenization, we decode the input_ids masked by -100  and get the following text：

```
### Instruction:
<p>I cannot locate within the FAQ whether this functionality exists in the API although its mentioned in a book as something that is potentially available. Has anyone had any experience implementing this feature?</p>

### Response:
As
```

The non-masked input_ids decoded are:
` an AI language model, I do not have access to the specific details of the book or the API you are referring to. Please provide more context or information so I can assist you better.</s>`
