### PR TITLE
Suzhiba/fix resume from checkpoint bug

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -197,7 +197,8 @@ def train(
         if os.path.exists(checkpoint_name):
             print(f"Restarting from {checkpoint_name}")
             adapters_weights = torch.load(checkpoint_name)
-            model = set_peft_model_state_dict(model, adapters_weights)
+            # there is no return in set_peft_model_state_dict.
+            set_peft_model_state_dict(model, adapters_weights)
         else:
             print(f"Checkpoint {checkpoint_name} not found")
 

--- a/finetune.py
+++ b/finetune.py
@@ -197,7 +197,6 @@ def train(
         if os.path.exists(checkpoint_name):
             print(f"Restarting from {checkpoint_name}")
             adapters_weights = torch.load(checkpoint_name)
-            # there is no return in set_peft_model_state_dict.
             set_peft_model_state_dict(model, adapters_weights)
         else:
             print(f"Checkpoint {checkpoint_name} not found")


### PR DESCRIPTION
Hi,
when use resume_from_checkpoint for lora params, the `model` is set to be None. 
There is no `return` in set_peft_model_state_dict(), so it should be used as `set_peft_model_state_dict(model, adapters_weights) ` rather than `model = set_peft_model_state_dict(model, adapters_weights)`