### PR TITLE
fix: Remove unnecessary model assignment in set_peft_model_state_dict

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -197,7 +197,7 @@ def train(
         if os.path.exists(checkpoint_name):
             print(f"Restarting from {checkpoint_name}")
             adapters_weights = torch.load(checkpoint_name)
-            model = set_peft_model_state_dict(model, adapters_weights)
+            set_peft_model_state_dict(model, adapters_weights)
         else:
             print(f"Checkpoint {checkpoint_name} not found")
 


### PR DESCRIPTION
**Description:** This pull request addresses a bug found in `finetune.py` related to the [`set_peft_model_state_dict()` ](https://github.com/huggingface/peft/blob/202f1d7c3d3f8dc468a989f9fb757e319be73d6f/src/peft/utils/save_and_load.py)function, which does not return a value. The issue was caused by the assignment of the function's result to `model`, leading to the `model` being set to None.

**Changes:** Removed the assignment of the `set_peft_model_state_dict()` result to `model`, the function now directly modifies the model without returning a value.