### PR TITLE
pin bitsandbytes version to avoid OOM issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 accelerate
 appdirs
 loralib
-bitsandbytes
+# bitsandbytes is pinned because newer versions cause OOM issues
+# see https://github.com/tloen/alpaca-lora/issues/344
+bitsandbytes==0.37.2
 black
 black[jupyter]
 datasets


### PR DESCRIPTION
The changes pins bits library to `0.37.2` because newer versions cause Cuda OOM issues. Please see the following issues for additional context: 
* https://github.com/tloen/alpaca-lora/issues/344
* https://github.com/TimDettmers/bitsandbytes/issues/324