### PR TITLE
fix bug: no adapter ckpt

### DIFF
--- a/export_hf_checkpoint.py
+++ b/export_hf_checkpoint.py
@@ -43,13 +43,6 @@ lora_model.train(False)
 # did we do anything?
 assert not torch.allclose(first_weight_old, first_weight)
 
-lora_model_sd = lora_model.state_dict()
-deloreanized_sd = {
-    k.replace("base_model.model.", ""): v
-    for k, v in lora_model_sd.items()
-    if "lora" not in k
-}
-
 LlamaForCausalLM.save_pretrained(
-    base_model, "./hf_ckpt", state_dict=deloreanized_sd, max_shard_size="400MB"
+    base_model, "./hf_ckpt", max_shard_size="400MB"
 )

--- a/finetune.py
+++ b/finetune.py
@@ -260,6 +260,9 @@ def train(
     )
     model.config.use_cache = False
 
+    if torch.__version__ >= "2" and sys.platform != "win32":
+        model = torch.compile(model)
+
     trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
     model.save_pretrained(output_dir)

--- a/finetune.py
+++ b/finetune.py
@@ -260,16 +260,6 @@ def train(
     )
     model.config.use_cache = False
 
-    old_state_dict = model.state_dict
-    model.state_dict = (
-        lambda self, *_, **__: get_peft_model_state_dict(
-            self, old_state_dict()
-        )
-    ).__get__(model, type(model))
-
-    if torch.__version__ >= "2" and sys.platform != "win32":
-        model = torch.compile(model)
-
     trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
     model.save_pretrained(output_dir)


### PR DESCRIPTION
`peft` change `get_peft_model_state_dict ` from `get_peft_model_state_dict(model, state_dict=None)` to `get_peft_model_state_dict(model, state_dict=None, adapter_name="default")`, so the ckpt at the end of the training is not saved. 

Change-Id: I1b21191e54c911b0463c47798d51c046d5857230