### PR TITLE
fix: peft version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ black
 black[jupyter]
 datasets
 fire
-git+https://github.com/huggingface/peft.git
+peft==0.3.0.dev0
 transformers>=4.28.0
 sentencepiece
 gradio


### PR DESCRIPTION
The current peft version doesn't work as the finetuning runs by a model is created with 443 bytes size but it's not fine-tuned, this PR addresses this issue and fixes it

closes #459 and #446 