### PR TITLE
[Requirements] Add scipy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ datasets
 fire
 git+https://github.com/huggingface/peft.git
 transformers>=4.28.0
+scipy
 sentencepiece
 gradio


### PR DESCRIPTION
#### Description
Adds scipy to `requirements.txt`.
Currently, following the steps in the README, `python generate.py` results in `ModuleNotFoundError: No module named 'scipy'`.

Closes #488