### PR TITLE
Fixes LoRA save issue

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -260,12 +260,12 @@ def train(
     )
     model.config.use_cache = False
 
-    old_state_dict = model.state_dict
-    model.state_dict = (
-        lambda self, *_, **__: get_peft_model_state_dict(
-            self, old_state_dict()
-        )
-    ).__get__(model, type(model))
+    #old_state_dict = model.state_dict
+    #model.state_dict = (
+    #    lambda self, *_, **__: get_peft_model_state_dict(
+    #        self, old_state_dict()
+    #    )
+    #).__get__(model, type(model))
 
     if torch.__version__ >= "2" and sys.platform != "win32":
         model = torch.compile(model)


### PR DESCRIPTION
Fixes the issue where adapter_model.bin is only 443 bytes when using the latest peft library.