### PR TITLE
Fix incompatibility with newer transformers versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ black[jupyter]
 datasets
 fire
 git+https://github.com/huggingface/peft.git
-transformers>=4.28.0
+transformers==4.30
 sentencepiece
 gradio


### PR DESCRIPTION
Currently when cloning the project and executing it after installing all dependencies, I get `ImportError: Using `load_in_8bit=True` requires Accelerate: 'pip install accelerate' and the latest version of bitsandbytes 'pip install -i https://test.pypi.org/simple/ bitsandbytes' or 'pip install bitsandbytes'`. [Others get this error too](https://stackoverflow.com/questions/76924239/accelerate-and-bitsandbytes-is-needed-to-install-but-i-did). Until then we should follow a working version.