### PR TITLE
Fix saved_pretrained saves empty adapter for new PEFT version. - Update finetune.py

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -260,12 +260,14 @@ def train(
     )
     model.config.use_cache = False
 
-    old_state_dict = model.state_dict
-    model.state_dict = (
-        lambda self, *_, **__: get_peft_model_state_dict(
-            self, old_state_dict()
-        )
-    ).__get__(model, type(model))
+    # to do
+    # if peft.__version__ < """:
+    #     old_state_dict = model.state_dict
+    #     model.state_dict = (
+    #         lambda self, *_, **__: get_peft_model_state_dict(
+    #             self, old_state_dict()
+    #         )
+    #     ).__get__(model, type(model))
 
     if torch.__version__ >= "2" and sys.platform != "win32":
         model = torch.compile(model)


### PR DESCRIPTION
Fix saved_pretrained saves empty adapter for new PEFT version.